### PR TITLE
Update analysis workflow: run on PR, java versions

### DIFF
--- a/.github/workflows/analyze-cli-java11.yml
+++ b/.github/workflows/analyze-cli-java11.yml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-name: Analyze with CodeGuru CLI (Java 11)
+name: Reviewer CLI (Java 11)
 
 on: [pull_request]
 
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   build:
-    name: Analyze with CodeGuru Reviewer CLI (Java 11)
+    name: Reviewer CLI (Java 11)
     runs-on: ubuntu-latest
     steps:
     - name: Assume IAM role

--- a/.github/workflows/analyze-cli.yml
+++ b/.github/workflows/analyze-cli.yml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-name: Analyze with CodeGuru CLI
+name: Reviewer CLI
 
 on: [pull_request]
 
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   build:
-    name: Analyze with CodeGuru Reviewer CLI
+    name: Reviewer CLI
     runs-on: ubuntu-latest
     steps:
     - name: Assume IAM role


### PR DESCRIPTION
- Switch to Java 8 bytecode.
- Keep analyzing Java 11 bytecode in a separate Action.
- Trigger on `pull_request` instead of `push`.
- Use shorter names to avoid truncation in UX.