### PR TITLE
Improve analysis logs

### DIFF
--- a/.github/workflows/analyze-cli-java11.yml
+++ b/.github/workflows/analyze-cli-java11.yml
@@ -96,11 +96,6 @@ jobs:
         path: code-guru/recommendations-summary-table.txt
         name: recommendations-summary-table.txt
 
-    - name: Print tabular summary of results to stdout
-      if: steps.assume-iam-role.outcome == 'success' && steps.analysis.outcome == 'success'
-      run: |
-        cat code-guru/recommendations-summary-table.txt | column -t
-
     - name: Find the number of the current PR
       uses: jwalton/gh-find-current-pr@v1
       id: findpr
@@ -116,3 +111,9 @@ jobs:
         # message does not seem to be displayed in comment when `path` option is used.
         message: |
           Summary of findings from CodeGuru Reviewer (more details in workflow artifacts)
+
+    - name: Print summary of results to stdout
+      if: steps.assume-iam-role.outcome == 'success' && steps.analysis.outcome == 'success'
+      run: |
+        cat code-guru/recommendations-summary-table.txt
+

--- a/.github/workflows/analyze-cli.yml
+++ b/.github/workflows/analyze-cli.yml
@@ -96,11 +96,6 @@ jobs:
         path: code-guru/recommendations-summary-table.txt
         name: recommendations-summary-table.txt
 
-    - name: Print tabular summary of results to stdout
-      if: steps.assume-iam-role.outcome == 'success' && steps.analysis.outcome == 'success'
-      run: |
-        cat code-guru/recommendations-summary-table.txt | column -t
-
     - name: Find the number of the current PR
       uses: jwalton/gh-find-current-pr@v1
       id: findpr
@@ -116,3 +111,9 @@ jobs:
         # message does not seem to be displayed in comment when `path` option is used.
         message: |
           Summary of findings from CodeGuru Reviewer (more details in workflow artifacts)
+
+    - name: Print summary of results to stdout
+      if: steps.assume-iam-role.outcome == 'success' && steps.analysis.outcome == 'success'
+      run: |
+        cat code-guru/recommendations-summary-table.txt
+

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -100,11 +100,6 @@ jobs:
         name: codeguru-results-ultra-summary-txt
         path: codeguru-results-ultra-summary.txt
 
-    - name: Print tabular summary of results to stdout
-      if: steps.assume-iam-role.outcome == 'success' && steps.analysis.outcome == 'success'
-      run: |
-        cat codeguru-results-ultra-summary.txt | column -t
-
     - name: Find the number of the current PR
       uses: jwalton/gh-find-current-pr@v1
       id: findpr
@@ -120,6 +115,11 @@ jobs:
         # message does not seem to be displayed in comment when `path` option is used.
         message: |
           Summary of findings from CodeGuru Reviewer (more details in workflow artifacts)
+
+    - name: Print summary of results to stdout
+      if: steps.assume-iam-role.outcome == 'success' && steps.analysis.outcome == 'success'
+      run: |
+        cat codeguru-results-ultra-summary.txt
 
     ####### Uploading to GitHub's code scan results UX will only work once the repo is public.
 


### PR DESCRIPTION
This improves the printing of analysis results summaries to stdout (which can then be found inside the workflow logs).

* Show results summary as the last step in the workflow (easier to find).
* Don't use `column -t` to show results. Columns are too wide; it's more readable without that.
* Sync same config for all analyses.