### PR TITLE
Update ClearTextCredentials.java

### DIFF
--- a/src/java/detectors/clear_text_credentials/ClearTextCredentials.java
+++ b/src/java/detectors/clear_text_credentials/ClearTextCredentials.java
@@ -12,7 +12,7 @@ import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 @Slf4j
 public class ClearTextCredentials {
 
-    // {fact rule=clear-text-credentials@v1.0 defects=1}
+    // {fact rule=sensitive-information-leak@v1.0 defects=1}
     public void logCredentialsNoncompliant() {
         String publicData = "some public data";
         AWSCredentials credentials = new DefaultAWSCredentialsProviderChain().getCredentials();
@@ -21,7 +21,7 @@ public class ClearTextCredentials {
     }
     // {/fact}
 
-    // {fact rule=clear-text-credentials@v1.0 defects=0}
+    // {fact rule=sensitive-information-leak@v1.0 defects=0}
     public void logCredentialsCompliant() {
         String publicData = "some public data";
         AWSCredentials credentials = new DefaultAWSCredentialsProviderChain().getCredentials();


### PR DESCRIPTION
As per the test case, Annotation should be of sensitive-information-leak@v1.0.

*Issue #, if available:*

*Description of changes:*  : We are getting FN in this test case for clear-text-credentials@v1.0, And as per the observation in test case, this seems to be testing sensitive-information-leak@v1.0 through the logs used inside code.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
